### PR TITLE
fix for key should not exist

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-ignore = E203, E266, E501, W503, F403, F401, W292, E402
+ignore = E203, E266, E501, W503, F403, F401, W292, E402, W391, W293
 max-line-length = 79
 max-complexity = 18

--- a/src/AWSLibrary/base/__init__.py
+++ b/src/AWSLibrary/base/__init__.py
@@ -10,3 +10,11 @@ logger.setLevel(logging.DEBUG)
 sh = logging.StreamHandler()
 sh.setFormatter(logging.Formatter(FORMAT))
 logger.addHandler(sh)
+
+
+__all__ = [
+    LibraryComponent,
+    KeywordError,
+    ContinuableError,
+    FatalError
+]

--- a/src/AWSLibrary/keywords/s3.py
+++ b/src/AWSLibrary/keywords/s3.py
@@ -105,7 +105,7 @@ class S3Keywords(LibraryComponent):
         try:
             if res['ResponseMetadata']['HTTPStatusCode'] == 404:
                 raise KeywordError("Key: {}, does not exist".format(key))
-        except ClientError as e: # noqa
+        except botocore.exceptions.ClientError as e:
             raise ContinuableError(e.response['Error'])
         return True
 
@@ -126,7 +126,7 @@ class S3Keywords(LibraryComponent):
                 raise KeywordError("Key: {}, already exists".format(key))
         except botocore.exceptions.ClientError as e: # noqa
             if e.response['ResponseMetadata']['HTTPStatusCode'] != 404:
-                raise ContinuableError(f"Error at: {e.operation_name} with data {e.response}")
+                raise ContinuableError("Error at: {} with data {}".format(e.operation_name, e.response))
 
     @keyword('Allowed Methods')
     def allowed_methods(self, bucket, methods=[]):
@@ -137,5 +137,5 @@ class S3Keywords(LibraryComponent):
             obj = response['CORSRules'][0]
             aws_methods = obj['AllowedMethods']
             assert set(aws_methods) == set(methods)
-        except ClientError as e:  # noqa
+        except botocore.exceptions.ClientError as e:
             raise KeywordError(e)

--- a/src/AWSLibrary/keywords/s3.py
+++ b/src/AWSLibrary/keywords/s3.py
@@ -124,9 +124,9 @@ class S3Keywords(LibraryComponent):
             res = client.head_object(Bucket=bucket, Key=key)
             if res['ResponseMetadata']['HTTPStatusCode'] == 200:
                 raise KeywordError("Key: {}, already exists".format(key))
-        except ClientError as e: # noqa
-            raise ContinuableError(e.response['Error'])
-        return True
+        except botocore.exceptions.ClientError as e: # noqa
+            if e.response['ResponseMetadata']['HTTPStatusCode'] != 404:
+                raise ContinuableError(f"Error at: {e.operation_name} with data {e.response}")
 
     @keyword('Allowed Methods')
     def allowed_methods(self, bucket, methods=[]):

--- a/tests/robot/testsuites/S3Tests/Key_Should_Exist.robot
+++ b/tests/robot/testsuites/S3Tests/Key_Should_Exist.robot
@@ -1,0 +1,18 @@
+*** Settings ***
+Library  Collections
+Library  AWSLibrary
+
+
+
+*** Variable ***
+${REGION}=  us-east-1
+${BUCKET}=  zappastaticbin
+${KEY}=  path_test.html
+
+
+
+*** Test Case ***
+Test Key Should Not Exist
+    Create Session With Keys  ${REGION}  ${ACCESS_KEY}  ${SECRET_KEY}
+    Key Should Exist  ${BUCKET}  ${KEY}
+    Delete All Sessions

--- a/tests/robot/testsuites/S3Tests/Key_Should_Exist.robot
+++ b/tests/robot/testsuites/S3Tests/Key_Should_Exist.robot
@@ -5,9 +5,9 @@ Library  AWSLibrary
 
 
 *** Variable ***
-${REGION}=  us-east-1
-${BUCKET}=  zappastaticbin
-${KEY}=  path_test.html
+${REGION}  us-east-1
+${BUCKET}  zappastaticbin
+${KEY}  path_test.html
 
 
 

--- a/tests/robot/testsuites/S3Tests/Key_Should_Not_Exist.robot
+++ b/tests/robot/testsuites/S3Tests/Key_Should_Not_Exist.robot
@@ -1,0 +1,17 @@
+*** Settings ***
+Library  Collections
+Library  AWSLibrary
+
+
+
+*** Variable ***
+${REGION}=  us-east-1
+${BUCKET}=  zappastaticbin
+${KEY}=  fail_test.html
+
+
+*** Test Case ***
+Test Key Should Not Exist
+    Create Session With Keys  ${REGION}  ${ACCESS_KEY}  ${SECRET_KEY}
+    Key Should Not Exist  ${BUCKET}  ${KEY}
+    Delete All Sessions

--- a/tests/robot/testsuites/S3Tests/Key_Should_Not_Exist.robot
+++ b/tests/robot/testsuites/S3Tests/Key_Should_Not_Exist.robot
@@ -3,11 +3,10 @@ Library  Collections
 Library  AWSLibrary
 
 
-
 *** Variable ***
-${REGION}=  us-east-1
-${BUCKET}=  zappastaticbin
-${KEY}=  fail_test.html
+${REGION}  us-east-1
+${BUCKET}  zappastaticbin
+${KEY}  fail_test.html
 
 
 *** Test Case ***


### PR DESCRIPTION
One thing I have thought of from this issue is taking the client error response into the exceptions class and dismantling the response object and formatted for the user.

The fix for this keyword is obvious and was something I obviously missed in a rush. I did not test it extensively. a robot test has been added, unit test is not complete.

