### PR TITLE
Fix link to keyword docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If there is functionality that should be included in this library please email m
 ---------------
 A library of keywords for interacting with AWS services in your robot tests. This library covers a variety of AWS services.
 
-[Documentation for Keywords](https://teaglebuilt.github.io/robotframework-AWS/)
+[Documentation for Keywords](https://teaglebuilt.github.io/robotframework-aws/)
 
 [Pypi](https://pypi.org/project/robotframework-aws/)
 ____________


### PR DESCRIPTION
the link to the keword docs is not resolving as it has uppercase "AWS" in it, but the gtihub pages are available on "https://teaglebuilt.github.io/robotframework-aws/" instead of "https://teaglebuilt.github.io/robotframework-AWS/"

This will fix the issue #38 