### PR TITLE
Updating to use latest version of Ubuntu for latest Node version.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Download reports
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: robot_reports
       - name: Send report to commit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   run-localstack-and-robot:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -49,7 +49,7 @@ jobs:
   generate-robot-report:
     if: always()
     needs: [ run-localstack-and-robot ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Download reports
         uses: actions/download-artifact@v1

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Run Robot Framework
       run: robot -d ./reports ./tests/robot
     - name: Upload test results
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: robot_reports


### PR DESCRIPTION
The image we use for github actions is using `ubuntu-latest` which is currently pinned to `ubuntu-22.04`. This is preventing us from updating some workflow actions that rely on a newer version of Node.

This update resolves that.